### PR TITLE
Obey index if set, pollute the global JS scope less

### DIFF
--- a/src/js/instant-meilisearch.js
+++ b/src/js/instant-meilisearch.js
@@ -1,43 +1,44 @@
 // INSTANT MEILISEARCH
 
-$searchUrl = $meilisearchSearchUrl === "" ? $meilisearchUrl : $meilisearchSearchUrl;
-const search = instantsearch({
-    indexName: "wordpress",
-    searchClient: instantMeiliSearch(
-        $searchUrl,
-        $meilisearchPublicKey,
-        {
-            limitPerRequest: 5,
-        }
-    )
-});
+function wpInstantMeilisearch(searchUrl, meilisearchPublicKey, indexName, searchElt, hitsElt) {
+    const search = instantsearch({
+        indexName: indexName,
+        searchClient: instantMeiliSearch(
+            searchUrl,
+            meilisearchPublicKey,
+            {
+                limitPerRequest: 5,
+            }
+        )
+    });
 
-search.addWidgets([
-    instantsearch.widgets.searchBox({
-        container: "#searchbox",
-        placeholder: "Search",
-        showReset: false,
-        showSubmit: false,
-    }),
-    instantsearch.widgets.hits({
-        container: "#hits",
-        templates: {
-            item: `
-                <a href="{{url}}">
-                <div class="single-hit">
-                    <div class="hit-img">
-                        <img src="{{img}}" />
-                    </div>
-                    <div class="hit-description">
-                        <div class="hit-name">
-                            {{#helpers.highlight}}{ "attribute": "title" }{{/helpers.highlight}}
+    search.addWidgets([
+        instantsearch.widgets.searchBox({
+            container: searchElt,
+            placeholder: "Search",
+            showReset: false,
+            showSubmit: false,
+        }),
+        instantsearch.widgets.hits({
+            container: hitsElt,
+            templates: {
+                item: `
+                    <a href="{{url}}">
+                    <div class="single-hit">
+                        <div class="hit-img">
+                            <img src="{{img}}" />
+                        </div>
+                        <div class="hit-description">
+                            <div class="hit-name">
+                                {{#helpers.highlight}}{ "attribute": "title" }{{/helpers.highlight}}
+                            </div>
                         </div>
                     </div>
-                </div>
-                </a>
-            `
-        },
-    }),
-]);
+                    </a>
+                `
+            },
+        }),
+    ]);
 
-search.start();
+    search.start();
+}

--- a/src/search_widget.php
+++ b/src/search_widget.php
@@ -70,19 +70,27 @@ class MeiliSearch_Widget extends WP_Widget {
 
             // Display text field
             if ( $text ) {
+                $search_elt_id = 'meilisearchbox';
+                $hits_elt_id = 'meilisearchhits';
+
                 // echo '<form><input type="text" placeholder="' . $text . '"/></form>';
-                echo '<div id="searchbox" class="ais-SearchBox"></div>';
-                echo '<div id="hits" class="ais-SearchBox"></div>';
+                echo '<div id="'.$search_elt_id.'" class="ais-SearchBox"></div>';
+                echo '<div id="'.$hits_elt_id.'" class="ais-SearchBox"></div>';
                 echo '<script src="'.'https://cdn.jsdelivr.net/npm/meilisearch/dist/bundles/meilisearch.browser.js'.'"></script>';
                 echo '<script src="'.'https://cdn.jsdelivr.net/npm/instantsearch.js@4'.'"></script>';
                 echo '<script src="https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch"></script>';
-                echo '<script>';
-                $meilisearch_options = get_option( 'meilisearch_option_name' );
-                echo 'let $meilisearchUrl = "'.$meilisearch_options['meilisearch_url_0'].'";';
-                echo 'let $meilisearchSearchUrl = "'.$meilisearch_options['meilisearch_search_url_4'].'";';
-                echo 'let $meilisearchPublicKey = "'.$meilisearch_options['meilisearch_public_key_2'].'";';
-                echo '</script>';
                 echo '<script src="'.plugin_dir_url( __FILE__ ) . 'js/instant-meilisearch.js'.'"></script>';
+                echo '<script>';
+
+                $meilisearch_options = get_option( 'meilisearch_option_name' );
+                $meilisearch_url = $meilisearch_options['meilisearch_url_0'];
+                $meilisearch_search_url = $meilisearch_options['meilisearch_search_url_4'];
+                $meilisearch_public_key = $meilisearch_options['meilisearch_public_key_2'];
+                $meilisearch_index_name = $meilisearch_options['meilisearch_index_name'];
+                $search_url = $meilisearch_search_url === "" ? $meilisearch_url : $meilisearch_search_url;
+
+                echo 'wpInstantMeilisearch("'.$search_url.'","'.$meilisearchPublicKey.'","'.$meilisearch_index_name.'","#'.$search_elt_id.'","#'.$hits_elt_id.'")';
+                echo '</script>';
             }
 
             echo '</div>';


### PR DESCRIPTION
While experimenting and playing around with this on a local wordpress installation I ended up doing some small changes and thought I'd make a PR. Specifically:

 - per #8, previously the frontend JS wasn't obeying the backend setting of index name
 - there were a few implicit dependencies between the .js and the .php code - I altered this to make the .js a function which can be called with appropriate parameters. This starts moving towards something that could allow multiple meilisearch instances on a page at once, as well as moving things out of the global javascript scope (previously generic names like 'search' were being used, which seemed risky)

Fixes #8